### PR TITLE
Add GitHub Pages deployment configuration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,53 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [ deploy-gh-pages ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+          
+      - name: Install dependencies
+        run: npm ci
+        
+      - name: Build
+        run: npm run build
+        
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+        
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: './dist'
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    branches: [ deploy-gh-pages ]
+    branches: [deploy-gh-pages]
   workflow_dispatch:
 
 permissions:
@@ -20,26 +20,26 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
-          cache: 'npm'
-          
+          node-version: "18"
+          # Remove cache: 'npm' since we don't have package-lock.json
+
       - name: Install dependencies
-        run: npm ci
-        
+        run: npm install # Use npm install instead of npm ci
+
       - name: Build
         run: npm run build
-        
+
       - name: Setup Pages
         uses: actions/configure-pages@v4
-        
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: './dist'
+          path: "./dist"
 
   deploy:
     environment:

--- a/README.md
+++ b/README.md
@@ -68,3 +68,4 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 ## Contributing
 
 Feel free to submit issues and enhancement requests!
+# Trigger deployment

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,11 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+// vite.config.js
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
 
-export default defineConfig({
+export default defineConfig(({ command }) => ({
   plugins: [react()],
-})
+  base: command === "build" ? "/pdf-viewer-poc/" : "/",
+  build: {
+    outDir: "dist",
+  },
+}));


### PR DESCRIPTION
This PR adds the necessary configuration to deploy the PDF Viewer POC to GitHub Pages.

### Changes Made:
- ✅ Updated `vite.config.js` with GitHub Pages base path configuration
- ✅ Added GitHub Actions workflow for automated deployment
- ✅ Configured build process for production deployment

### Files Added/Modified:
- `vite.config.js` - Added base path for GitHub Pages
- `.github/workflows/deploy.yml` - GitHub Actions deployment workflow

### Testing:
- [ ] Local development still works (`npm run dev`)
- [ ] Production build works (`npm run build`)
- [ ] GitHub Pages deployment is configured
- [ ] Site is accessible at https://reneang17.github.io/pdf-viewer-poc/